### PR TITLE
feat: Decrease trace limit.

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,6 +269,8 @@ class Logger {
   static getStack(belowFn) {
     const v8Handler = Error.prepareStackTrace
     const dummyObject = {}
+    const stackTraceLimit = Error.stackTraceLimit
+    Error.stackTraceLimit = 1
 
     Error.prepareStackTrace = function(dummyObject, v8StackTrace) {
       return v8StackTrace
@@ -277,6 +279,7 @@ class Logger {
 
     const v8StackTrace = dummyObject.stack
 
+    Error.stackTraceLimit = stackTraceLimit
     Error.prepareStackTrace = v8Handler
 
     return v8StackTrace


### PR DESCRIPTION
stack trace 深度限制为 1 以减少不必的堆栈获取消耗。使用 winston log 时简单堆栈情况下提升10-20%，堆栈越深效果越明显。